### PR TITLE
Avoid using qt5_use_modules

### DIFF
--- a/src/gui/QtHRG/CMakeLists.txt
+++ b/src/gui/QtHRG/CMakeLists.txt
@@ -31,10 +31,8 @@ if(WIN32)
   endif()
 endif()
 
-qt5_use_modules(QtThermalFIST Widgets PrintSupport)
-
 # Use the Widgets module from Qt 5.
-target_link_libraries(QtThermalFIST ThermalFIST)
+target_link_libraries(QtThermalFIST ThermalFIST Qt5::Core Qt5::Widgets Qt5::PrintSupport)
 set_property(TARGET QtThermalFIST PROPERTY RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin")
 
 


### PR DESCRIPTION
Hi @vlvovch ,

this is the small change I was mentioning today. Have a look locally if that works also for you (it does for me on mac and Ubuntu 14).

Cheers,
Max