### PR TITLE
Version 1.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,8 +7,8 @@ project (ThermalFIST)
 
 # The version number.
 set (ThermalFIST_VERSION_MAJOR 1)
-set (ThermalFIST_VERSION_MINOR 1)
-set (ThermalFIST_VERSION_DEVEL 6)
+set (ThermalFIST_VERSION_MINOR 2)
+set (ThermalFIST_VERSION_DEVEL 0)
 
 # configure a header file to pass some of the CMake settings
 # to the source code

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ project (ThermalFIST)
 # The version number.
 set (ThermalFIST_VERSION_MAJOR 1)
 set (ThermalFIST_VERSION_MINOR 1)
-set (ThermalFIST_VERSION_DEVEL 5)
+set (ThermalFIST_VERSION_DEVEL 6)
 
 # configure a header file to pass some of the CMake settings
 # to the source code

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ project (ThermalFIST)
 # The version number.
 set (ThermalFIST_VERSION_MAJOR 1)
 set (ThermalFIST_VERSION_MINOR 1)
-set (ThermalFIST_VERSION_DEVEL 4)
+set (ThermalFIST_VERSION_DEVEL 5)
 
 # configure a header file to pass some of the CMake settings
 # to the source code

--- a/include/HRGBase/ThermalModelBase.h
+++ b/include/HRGBase/ThermalModelBase.h
@@ -454,6 +454,12 @@ namespace thermalfist {
     /// by the condition of charm neutrality
     void ConstrainMuC(bool constrain) { m_ConstrainMuC = constrain; }
 
+    /// Sets whether partial chemical equilibrium with additional chemical potentials is used
+    void UsePartialChemicalEquilibrium(bool usePCE) { m_PCE = usePCE; }
+
+    /// Whether partial chemical equilibrium with additional chemical potentials is used
+    bool UsePartialChemicalEquilibrium() { return m_PCE; }
+
     //@{
       /**
        * \brief The entropy per baryon ratio
@@ -1046,6 +1052,8 @@ namespace thermalfist {
     bool m_ConstrainMuQ;
     bool m_ConstrainMuS;
     bool m_ConstrainMuC;
+
+    bool m_PCE;
 
     bool m_useOpenMP;
 

--- a/include/HRGBase/xMath.h
+++ b/include/HRGBase/xMath.h
@@ -61,6 +61,11 @@ namespace thermalfist {
     double BesselK1exp(double x);         // modified Bessel function K_1(x), divided by exponential factor
     double BesselKexp(int n, double x);    // integer order modified Bessel function K_n(x), divided by exponential factor
 
+    double BesselI0exp(double x);         // modified Bessel function I_0(x), divided by exponential factor
+    double BesselI1exp(double x);         // modified Bessel function I_1(x), divided by exponential factor
+    double BesselIexp(int n, double x);   // integer order modified Bessel function I_n(x), divided by exponential factor
+
+
     // Note that the functions Gamma and LogGamma are mutually dependent.
     double LogGamma(double);
     double Gamma(double);

--- a/include/HRGEventGenerator/CylindricalBlastWaveEventGenerator.h
+++ b/include/HRGEventGenerator/CylindricalBlastWaveEventGenerator.h
@@ -29,31 +29,40 @@ namespace thermalfist {
      * \param TPS    A pointer to the particle list
      * \param config Event generator configuration
      * \param Tkin   The kinetic freeze-out temperature (in GeV) 
-     * \param beta   The transverse flow velocity
+     * \param betas  The transverse flow velocity at the surface
      * \param etamax The longitudinal space-time rapidity cut-off
      * \param npow   The power in the transverse flow profile function
      */
     CylindricalBlastWaveEventGenerator(ThermalParticleSystem *TPS, 
                                        const EventGeneratorConfiguration& config, 
                                        double T = 0.120, 
-                                       double beta = 0.5, 
+                                       double betas = 0.5, 
                                        double etamax = 0.5, 
                                        double npow = 1.);
     
     /// \deprecated
     /// \brief Old constructor. Included for backward compatibility.
-    CylindricalBlastWaveEventGenerator(ThermalModelBase *THM, double T = 0.120, double beta = 0.5, double etamax = 0.5, double npow = 1., bool onlyStable = false, EventGeneratorConfiguration::ModelType EV = EventGeneratorConfiguration::PointParticle, ThermalModelBase *THMEVVDW = NULL);
+    CylindricalBlastWaveEventGenerator(ThermalModelBase *THM, double T = 0.120, double betas = 0.5, double etamax = 0.5, double npow = 1., bool onlyStable = false, EventGeneratorConfiguration::ModelType EV = EventGeneratorConfiguration::PointParticle, ThermalModelBase *THMEVVDW = NULL);
     
     ~CylindricalBlastWaveEventGenerator() { }
 
     /// Sets the momentum distribution parameters
-    void SetParameters(double T, double beta, double etamax, double npow = 1.);
+    void SetParameters(double T, double betas, double etamax, double npow = 1.);
+
+    /**
+     * \brief Set the mean transverse flow velocity.
+     *
+     * Surface velocity is calculated as \\beta_s = \\langle \\beta_T \\rangle (2+n)/2 
+     * 
+     * \param betaT  The mean transverse flow velocity
+     */
+    void SetMeanBetaT(double betaT);
 
     /// Sets up the random generators of particle momenta
     /// and resonances masses
     void SetMomentumGenerators();
   private:
-    double m_T, m_Beta, m_EtaMax, m_n;
+    double m_T, m_BetaS, m_EtaMax, m_n;
   };
 
   /// For backward compatibility

--- a/include/HRGEventGenerator/EventGeneratorBase.h
+++ b/include/HRGEventGenerator/EventGeneratorBase.h
@@ -136,6 +136,15 @@ namespace thermalfist {
     /// sampling used for canonical ensemble and/or eigenvolumes.
     static int fCEAccepted, fCETotal;
 
+    /// Set system volume
+    /// Can be used to include volume fluctuations
+    /**
+     * \brief Set system volume.
+     * 
+     * Can be used to include volume fluctuations
+     */
+    void SetVolume(double V) { m_THM->SetVolume(V); m_Config.CFOParameters.V = V; }
+
   protected:
     /**
      * \brief Sets the event generator configuration.

--- a/include/HRGEventGenerator/EventGeneratorBase.h
+++ b/include/HRGEventGenerator/EventGeneratorBase.h
@@ -37,7 +37,7 @@ namespace thermalfist {
     /// Enumerates the statistical ensembles 
     enum Ensemble { 
       GCE, ///< Grand-canonical
-      CE,  ///< Caonical
+      CE,  ///< Canonical
       SCE, ///< Strangeness-canonical
       CCE  ///< Charm-canonical
     };
@@ -68,6 +68,15 @@ namespace thermalfist {
 
     /// The matrix of van der Waals attraction coefficients \f$ a_{ij} \f$
     std::vector< std::vector<double> > aij;
+
+    /// Whether partial chemical equilibrium is used
+    bool fUsePCE;
+
+    /// PCE chemical potentials
+    std::vector<double> fPCEChems;
+
+
+    EventGeneratorConfiguration();
   };
 
   /// \brief Base class for generating events with the Thermal Event Generator

--- a/include/HRGEventGenerator/EventGeneratorBase.h
+++ b/include/HRGEventGenerator/EventGeneratorBase.h
@@ -136,14 +136,20 @@ namespace thermalfist {
     /// sampling used for canonical ensemble and/or eigenvolumes.
     static int fCEAccepted, fCETotal;
 
-    /// Set system volume
-    /// Can be used to include volume fluctuations
     /**
      * \brief Set system volume.
      * 
      * Can be used to include volume fluctuations
      */
-    void SetVolume(double V) { m_THM->SetVolume(V); m_Config.CFOParameters.V = V; }
+    void SetVolume(double V);
+
+    /**
+     * \brief Rescale precalculated GCE means. 
+     * 
+     * Called when the system volume is changed
+     */
+    void RescaleCEMeans(double Vmod);
+
 
   protected:
     /**

--- a/include/HRGEventGenerator/MomentumDistribution.h
+++ b/include/HRGEventGenerator/MomentumDistribution.h
@@ -151,14 +151,14 @@ namespace thermalfist {
     /**
      * \copydoc MomentumDistributionBase()
      * \param T      The kinetic temperature (in GeV)
-     * \param beta   The transverse flow velocity
+     * \param beta   The transverse flow velocity at the surface
      * \param etamax The longitudinal space-time rapidity cut-off
      * \param npow   The power in the transverse flow profile function
      * \param norm   Whether the momentum distribution should be normalized to unity 
      */
-    SSHDistribution(int pdgid = 0, double mass = 0., double T = 0.100, double beta = 0.5, double etamax = 0.5, double npow = 1., bool norm = false) :
+    SSHDistribution(int pdgid = 0, double mass = 0., double T = 0.100, double betas = 0.5, double etamax = 0.5, double npow = 1., bool norm = false) :
       MomentumDistributionBase(pdgid, mass),
-      m_T(T), m_Beta(beta), m_EtaMax(etamax), m_n(npow)
+      m_T(T), m_BetaS(betas), m_EtaMax(etamax), m_n(npow)
     {
       m_NormY = m_NormPt = m_Norm = 1.;
       if (norm) Normalize();
@@ -172,16 +172,16 @@ namespace thermalfist {
      * \brief Set the parameters of the longitudinal blast-wave distribution
      * 
      * \param T      The kinetic temperature (in GeV)
-     * \param beta   The transverse flow velocity
+     * \param betas  The transverse flow velocity at the surface
      * \param etamax The longitudinal space-time rapidity cut-off
      * \param npow   The power in the transverse flow profile function
      * \param mass   Particle mass (in GeV)
      * \param pdgid  Particle PDG code
      * \param norm   Whether the momentum distribution should be normalized to unity 
      */
-    void SetParameters(double T, double beta, double etamax, double npow, double mass, int pdgid = 0, bool norm = true) {
+    void SetParameters(double T, double betas, double etamax, double npow, double mass, int pdgid = 0, bool norm = true) {
       m_T = T;
-      m_Beta = beta;
+      m_BetaS = betas;
       m_EtaMax = etamax;
       m_n = npow;
       m_Mass = mass;
@@ -190,6 +190,17 @@ namespace thermalfist {
       m_Normalized = false;
       if (norm) Normalize();
       else Initialize();
+    }
+
+    /**
+     * \brief Set the mean transverse flow velocity.
+     *
+     * Surface velocity is calculated as \\beta_s = \\langle \\beta_T \\rangle (2+n)/2 
+     * 
+     * \param betaT  The mean transverse flow velocity
+     */
+    void SetMeanBetaT(double betaT) {
+      m_BetaS = (2. + m_n) / 2. * betaT;
     }
 
     void Normalize();
@@ -239,11 +250,11 @@ namespace thermalfist {
 
     double betar(double r) const {
       if (m_n == 1.)
-        return m_Beta * r;
+        return m_BetaS * r;
       else if (m_n == 2.)
-        return m_Beta * r * m_Beta * r;
+        return m_BetaS * r * r;
       else
-        return pow(m_Beta * r, m_n);
+        return m_BetaS * pow(r, m_n);
     }
 
     double rho(double r) const { return atanh(betar(r)); }
@@ -253,7 +264,7 @@ namespace thermalfist {
     double y2Av() const;
 
     double m_T;
-    double m_Beta, m_EtaMax;
+    double m_BetaS, m_EtaMax;
     double m_NormY, m_NormPt, m_Norm;
     double m_n;
     std::vector<double> m_xlag, m_wlag;

--- a/include/HRGEventGenerator/RandomGenerators.h
+++ b/include/HRGEventGenerator/RandomGenerators.h
@@ -37,6 +37,50 @@ namespace thermalfist {
     /// \param rangen A Mersenne Twister random number generator to use
     int RandomPoisson(double mean, MTRand &rangen);
 
+    /// \brief Probability of a Skellam distributed random variable with Poisson means
+    ///        mu1 and mu2 to have the value of k.
+    double SkellamProbability(int k, double mu1, double mu2);
+
+
+    /// \brief Generator of a random number from the Bessel distribution (a, nu), nu is integer
+    ///        Uses methods from https://www.sciencedirect.com/science/article/pii/S016771520200055X
+    ///        Used in event generator with exact conservation of charges to
+    ///        generate two Poisson numbers with fixed difference, as described in https://arxiv.org/pdf/1609.01087.pdf
+    struct BesselDistributionGenerator
+    {
+      static double pn(int n, double a, int nu);
+
+      static double R(double x, int nu) { return xMath::BesselI(nu + 1, x) / xMath::BesselI(nu, x); }
+
+      static double mu(double a, int nu) { return a * R(a, nu) / 2; }
+
+      static double chi2(double a, int nu);
+
+      static int    m(double a, int nu) { return static_cast<int>((sqrt(a*a+static_cast<double>(nu)*nu) - nu)/2.); }
+
+      static double sig2(double a, int nu);
+
+      static double Q2(double a, int nu);
+
+      static int RandomBesselPoisson(double a, int nu, MTRand &rangen);
+
+      static int RandomBesselPoisson(double a, int nu) { return RandomBesselPoisson(a, nu, randgenMT); }
+
+      static double pmXmOverpm(int X, int tm, double a, int nu);
+
+      static int RandomBesselDevroye1(double a, int nu, MTRand &rangen);
+
+      static int RandomBesselDevroye1(double a, int nu) { return RandomBesselDevroye1(a, nu, randgenMT); }
+
+      static int RandomBesselDevroye2(double a, int nu, MTRand &rangen);
+
+      static int RandomBesselDevroye2(double a, int nu) { return RandomBesselDevroye2(a, nu, randgenMT); }
+
+      static int RandomBesselDevroye3(double a, int nu, MTRand &rangen);
+
+      static int RandomBesselDevroye3(double a, int nu) { return RandomBesselDevroye3(a, nu, randgenMT); }
+    };
+
 
     /// \brief Base class for Monte Carlo sampling of particle momenta
     class ParticleMomentumGenerator

--- a/include/HRGEventGenerator/RandomGenerators.h
+++ b/include/HRGEventGenerator/RandomGenerators.h
@@ -50,7 +50,8 @@ namespace thermalfist {
     {
       static double pn(int n, double a, int nu);
 
-      static double R(double x, int nu) { return xMath::BesselI(nu + 1, x) / xMath::BesselI(nu, x); }
+      //static double R(double x, int nu) { return xMath::BesselI(nu + 1, x) / xMath::BesselI(nu, x); }
+      static double R(double x, int nu);
 
       static double mu(double a, int nu) { return a * R(a, nu) / 2; }
 
@@ -79,6 +80,14 @@ namespace thermalfist {
       static int RandomBesselDevroye3(double a, int nu, MTRand &rangen);
 
       static int RandomBesselDevroye3(double a, int nu) { return RandomBesselDevroye3(a, nu, randgenMT); }
+
+      static int RandomBesselNormal(double a, int nu, MTRand &rangen);
+
+      static int RandomBesselNormal(double a, int nu) { return RandomBesselNormal(a, nu, randgenMT); }
+
+      static int RandomBesselCombined(double a, int nu, MTRand &rangen);
+
+      static int RandomBesselCombined(double a, int nu) { return RandomBesselCombined(a, nu, randgenMT); }
     };
 
 

--- a/include/HRGEventGenerator/RandomGenerators.h
+++ b/include/HRGEventGenerator/RandomGenerators.h
@@ -204,13 +204,13 @@ namespace thermalfist {
       /**
        * \brief Construct a new SSHGenerator object
        * \param T      The kinetic temperature (in GeV)
-       * \param beta   The transverse flow velocity
+       * \param betas  The transverse flow velocity at the surface
        * \param etamax The longitudinal space-time rapidity cut-off
        * \param npow   The power in the transverse flow profile function
        * \param mass   Particle mass (in GeV) 
        */
-      SSHMomentumGenerator(double T, double beta, double etamax, double npow, double mass) :m_T(T), m_Beta(beta), m_EtaMax(etamax), m_n(npow), m_Mass(mass) {
-        m_distr = SSHDistribution(0, m_Mass, m_T, m_Beta, m_EtaMax, m_n, false);
+      SSHMomentumGenerator(double T, double betas, double etamax, double npow, double mass) :m_T(T), m_BetaS(betas), m_EtaMax(etamax), m_n(npow), m_Mass(mass) {
+        m_distr = SSHDistribution(0, m_Mass, m_T, m_BetaS, m_EtaMax, m_n, false);
         m_dPt = 0.02;
         m_dy = 0.05;
         FixParameters2();
@@ -223,18 +223,33 @@ namespace thermalfist {
        * \brief Sets the parameters of the distribution
        * 
        * \param T      The kinetic temperature (in GeV)
-       * \param beta   The transverse flow velocity
+       * \param betas  The transverse flow velocity at the surface
        * \param etamax The longitudinal space-time rapidity cut-off
        * \param npow   The power in the transverse flow profile function
        * \param mass   Particle mass (in GeV) 
        */
-      void SetParameters(double T, double beta, double etamax, double npow, double mass) {
+      void SetParameters(double T, double betas, double etamax, double npow, double mass) {
         m_T = T;
-        m_Beta = beta;
+        m_BetaS = betas;
         m_EtaMax = etamax;
         m_Mass = mass;
         m_n = npow;
-        m_distr = SSHDistribution(0, m_Mass, m_T, m_Beta, m_EtaMax, m_n);
+        m_distr = SSHDistribution(0, m_Mass, m_T, m_BetaS, m_EtaMax, m_n);
+        m_dPt = 0.02;
+        m_dy = 0.05;
+        FixParameters2();
+      }
+
+      /**
+        * \brief Set the mean transverse flow velocity.
+        *
+        * Surface velocity is calculated as \\beta_s = \\langle \\beta_T \\rangle (2+n)/2 
+        * 
+        * \param betaT  The mean transverse flow velocity
+        */
+      void SetMeanBetaT(double betaT) {
+        m_BetaS = (2. + m_n) / 2. * betaT;
+        m_distr = SSHDistribution(0, m_Mass, m_T, m_BetaS, m_EtaMax, m_n);
         m_dPt = 0.02;
         m_dy = 0.05;
         FixParameters2();
@@ -275,7 +290,7 @@ namespace thermalfist {
 
       std::pair<double, double> GetRandom2() const;
 
-      double m_T, m_Beta, m_EtaMax, m_n, m_Mass;
+      double m_T, m_BetaS, m_EtaMax, m_n, m_Mass;
       double m_MaxY, m_MaxPt;
       SSHDistribution m_distr;
       SplineFunction m_dndpt;

--- a/include/HRGEventGenerator/SimpleEvent.h
+++ b/include/HRGEventGenerator/SimpleEvent.h
@@ -23,14 +23,22 @@ namespace thermalfist {
     /// Log of the event weight factor
     double logweight;
 
-    /// Vector of all particles in the event
+    /// Vector of all final particles in the event
     std::vector<SimpleParticle> Particles;
 
+     /// Vector of all particles which ever appeared in the event (including those that decay)
+    std::vector<SimpleParticle> AllParticles;
+
     /// Default constructor, empty event
-    SimpleEvent() { Particles.resize(0); weight = 1.; }
+    SimpleEvent() { Particles.resize(0); AllParticles.resize(0); weight = 1.; }
 
     /// Writes the event to an output file stream
     void writeToFile(std::ofstream & fout, int eventnumber = 1);
+
+    /// Rapidity boost for all particles
+    void RapidityBoost(double dY);
+
+    static SimpleEvent MergeEvents(const SimpleEvent &evt1, const SimpleEvent &evt2);
   };
 
 } // namespace thermalfist

--- a/include/HRGEventGenerator/SimpleParticle.h
+++ b/include/HRGEventGenerator/SimpleParticle.h
@@ -1,7 +1,7 @@
 /*
  * Thermal-FIST package
  * 
- * Copyright (c) 2014-2018 Volodymyr Vovchenko
+ * Copyright (c) 2014-2019 Volodymyr Vovchenko
  *
  * GNU General Public License (GPLv3 or later)
  */
@@ -18,6 +18,7 @@ namespace thermalfist {
     double p0;         ///< Energy (in GeV)
     long long PDGID;         ///< PDG code
     long long MotherPDGID;   ///< PDG code of a mother particle, if applicable
+    int epoch;               ///< 0 - primary particle, 1 - after decay of primary particles, 2 - after a casacde of two decays and so on...
     bool processed;          ///< Used in event generator
 
     /// Default constructor
@@ -30,7 +31,7 @@ namespace thermalfist {
       pz(inPz),
       m(inM),
       p0(sqrt(m*m + px * px + py * py + pz * pz)),
-      PDGID(inPDGID), MotherPDGID(inMotherPDGID), processed(false) { }
+      PDGID(inPDGID), MotherPDGID(inMotherPDGID), epoch(0), processed(false) { }
 
     /// Absolute value of the 3-momentum (in GeV)
     double GetP() const {
@@ -56,6 +57,12 @@ namespace thermalfist {
     double GetEta() const {
       //return atanh(pz/GetP());
       return 0.5*log((GetP() + pz) / (GetP() - pz));
+    }
+
+    /// Rapidity boost
+    void RapidityBoost(double dY) {
+      pz = GetMt() * sinh(GetY() + dY);
+      p0 = sqrt(m*m + px * px + py * py + pz * pz);
     }
   };
 

--- a/src/gui/QtThermalFIST/SpectralFunctionDialog.cpp
+++ b/src/gui/QtThermalFIST/SpectralFunctionDialog.cpp
@@ -111,6 +111,8 @@ SpectralFunctionDialog::SpectralFunctionDialog(QWidget *parent, ThermalParticle 
   setWindowTitle(QString(particle->Name().c_str()) + tr(" spectral function"));
 
   calculate();
+
+  cpath = QApplication::applicationDirPath();
 }
 
 void SpectralFunctionDialog::replot()
@@ -185,7 +187,9 @@ void SpectralFunctionDialog::replotSpectralFunctions()
     plot->graph(1)->addData(BWm[i], mnozh * BWTHval[i]);
   }
 
-  
+  plot->setContextMenuPolicy(Qt::CustomContextMenu);
+  connect(plot, SIGNAL(customContextMenuRequested(QPoint)), this, SLOT(contextMenuRequest(QPoint)));
+
 
   plot->replot();
 }
@@ -474,6 +478,115 @@ void SpectralFunctionDialog::calculate()
   }
 
   replot();
+}
+
+void SpectralFunctionDialog::contextMenuRequest(QPoint pos)
+{
+  QMenu *menu = new QMenu(this);
+  menu->setAttribute(Qt::WA_DeleteOnClose);
+
+  menu->addAction("Save as pdf", this, SLOT(saveAsPdf()));
+  menu->addAction("Save as png", this, SLOT(saveAsPng()));
+  menu->addAction("Write computed values to file", this, SLOT(saveAsAscii()));
+
+  menu->popup(plot->mapToGlobal(pos));
+}
+
+void SpectralFunctionDialog::saveAsPdf()
+{
+  saveAs(0);
+}
+
+void SpectralFunctionDialog::saveAsPng()
+{
+  saveAs(1);
+}
+
+void SpectralFunctionDialog::saveAsAscii()
+{
+  saveAs(2);
+}
+
+void SpectralFunctionDialog::saveAs(int type)
+{
+  QString tname = QString::fromStdString(particle->Name());
+  if (comboView->currentIndex() == 0)
+    tname += "_spectral";
+  else if (comboView->currentIndex() == 1)
+    tname += "_BRs";
+  else
+    tname += "_widths";
+  for (int i = 0; i < tname.size(); ++i) {
+    if (tname[i] == '/')
+      tname[i] = '.';
+  }
+
+  QVector<QString> exts;
+  exts.push_back("pdf");
+  exts.push_back("png");
+  exts.push_back("dat");
+
+  QString listpathprefix = cpath + "/" + tname + "." + exts[type];
+  QString path = QFileDialog::getSaveFileName(this, "Save plot as " + exts[type], listpathprefix, "*." + exts[type]);
+  if (path.length()>0)
+  {
+    if (type == 0)
+      plot->savePdf(path, plot->width(), plot->height());
+    else if (type == 1)
+      plot->savePng(path, plot->width(), plot->height());
+    else {
+      QFile fout(path);
+
+      if (fout.open(QIODevice::WriteOnly | QIODevice::Text)) {
+        QTextStream out(&fout);
+        if (comboView->currentIndex() == 0) {
+          out.setFieldWidth(20);
+          out.setFieldAlignment(QTextStream::AlignLeft);
+          out << "M[GeV]";
+          out << "rho[GeV^-1]_vac";
+          out << "rho[GeV^-1]_th";
+          out << qSetFieldWidth(0) << endl << qSetFieldWidth(20);
+          for (int i = 0; i < plot->graph(0)->dataCount(); ++i) {
+            out.setFieldWidth(20);
+            out.setFieldAlignment(QTextStream::AlignLeft);
+            out << plot->graph(0)->dataMainKey(i);
+            out << plot->graph(0)->dataMainValue(i);
+            out << plot->graph(1)->dataMainValue(i);
+            out << qSetFieldWidth(0) << endl << qSetFieldWidth(20);
+          }
+        }
+        else  {
+          out.setFieldWidth(30);
+          out.setFieldAlignment(QTextStream::AlignLeft);
+          out << "M[GeV]";
+          for (int ch = 0; ch < plot->graphCount(); ++ch) {
+            QString tnamech = "";
+            const QString& name = plot->graph(ch)->name();
+            for (int ic = 0; ic < name.size(); ++ic)
+              if (name[ic] != QChar(' '))
+                tnamech += name[ic];
+            if (comboView->currentIndex() == 1)
+              out << "BR_" + tnamech;
+            else
+              out << "Gamm_" + tnamech + "[GeV]";
+          }
+          out << qSetFieldWidth(0) << endl << qSetFieldWidth(30);
+          for (int i = 0; i < plot->graph(0)->dataCount(); ++i) {
+            out.setFieldWidth(30);
+            out.setFieldAlignment(QTextStream::AlignLeft);
+            out << plot->graph(0)->dataMainKey(i);
+            for (int ch = 0; ch < plot->graphCount(); ++ch) {
+              out << plot->graph(ch)->dataMainValue(i);
+            }
+            out << qSetFieldWidth(0) << endl << qSetFieldWidth(30);
+          }
+        }
+      }
+    }
+    
+    QFileInfo saved(path);
+    cpath = saved.absolutePath();
+  }
 }
 
 

--- a/src/gui/QtThermalFIST/SpectralFunctionDialog.h
+++ b/src/gui/QtThermalFIST/SpectralFunctionDialog.h
@@ -63,6 +63,8 @@ class SpectralFunctionDialog : public QDialog
     //QCPColorMap *colormap;
     //QCPColorScale *colorScale;
 
+    QString cpath;
+
     QComboBox *comboScheme;
 
     QDoubleSpinBox *spinT;
@@ -86,6 +88,13 @@ public slots:
     void replotSpectralFunctions();
     void replotBranchingRatios();
     void replotPartialWidths();
+
+    void contextMenuRequest(QPoint pos);
+    void saveAsPdf();
+    void saveAsPng();
+    void saveAsAscii();
+    // saveAs type: 0 - pdf, 1 - png, 2 - ascii data
+    void saveAs(int type);
 };
 
 #endif // SPECTRALFUNCTIONDIALOG_H

--- a/src/gui/QtThermalFIST/eventgeneratortab.cpp
+++ b/src/gui/QtThermalFIST/eventgeneratortab.cpp
@@ -374,7 +374,7 @@ EventGeneratorTab::EventGeneratorTab(QWidget *parent, ThermalModelBase *modelop)
     spinBeta->setDecimals(3);
     spinBeta->setValue(0.5);
     spinBeta->setToolTip(tr("Radial flow velocity"));
-    QLabel *labelBetat = new QLabel(tr("β<sub>T</sub>:"));
+    QLabel *labelBetat = new QLabel(tr("⟨β<sub>T</sub>⟩:"));
     spinBetat = new QDoubleSpinBox();
     spinBetat->setMinimum(0.);
     spinBetat->setMaximum(1.);
@@ -1067,10 +1067,11 @@ void EventGeneratorTab::generateEvents(const ThermalModelConfig & config)
 
     model->CalculateDensitiesGCE();
 
-
+    // Convert the mean transverse velocity into the one at the surface
+    double betaS = (2. + spinn->value()) / 2. * spinBetat->value();
 
     if (radioSR->isChecked()) spectra->Reset(model, spinTkin->value() * 1.e-3, spinBeta->value());
-    else if (radioSSH->isChecked()) spectra->Reset(model, spinTkin->value() * 1.e-3, spinBetat->value(), 1, spinEtaMax->value(), spinn->value());
+    else if (radioSSH->isChecked()) spectra->Reset(model, spinTkin->value() * 1.e-3, betaS, 1, spinEtaMax->value(), spinn->value());
 
     int id = getCurrentRow();
     if (id<0) id = 0;
@@ -1127,7 +1128,7 @@ void EventGeneratorTab::generateEvents(const ThermalModelConfig & config)
     if (radioSR->isChecked())
       generator = new SphericalBlastWaveEventGenerator(model->TPS(), configMC, spinTkin->value() * 1.e-3, spinBeta->value());
     else 
-      generator = new CylindricalBlastWaveEventGenerator(model->TPS(), configMC, spinTkin->value() * 1.e-3, spinBetat->value(), spinEtaMax->value(), spinn->value());
+      generator = new CylindricalBlastWaveEventGenerator(model->TPS(), configMC, spinTkin->value() * 1.e-3, betaS, spinEtaMax->value(), spinn->value());
 
 
     //if (radioSR->isChecked()) generator = new SphericalBlastWaveEventGenerator(model, spinTkin->value() * 1.e-3, spinBeta->value(), false, EV, modelEVVDW);

--- a/src/gui/QtThermalFIST/resultdialog.cpp
+++ b/src/gui/QtThermalFIST/resultdialog.cpp
@@ -239,6 +239,24 @@ QString ResultDialog::GetResults() {
   ret += QString(cc);
   ret += QString::number((model->CalculateEntropyDensity()) / model->Parameters().T / model->Parameters().T / model->Parameters().T / xMath::GeVtoifm() / xMath::GeVtoifm() / xMath::GeVtoifm()) + "\r\n";
 
+  if (model->TPS()->PdgToId(2212) != -1 && model->TPS()->PdgToId(1000010020) != -1) {
+    ret += "\r\n";
+
+    sprintf(cc, "%-25s = ", "O_p,d = N_d/N_p^2");
+    ret += QString(cc);
+    ret += QString::number( model->TotalDensities()[model->TPS()->PdgToId(1000010020)] / model->TotalDensities()[model->TPS()->PdgToId(2212)] / model->TotalDensities()[model->TPS()->PdgToId(2212)] ) + "\r\n";
+
+    if (model->TPS()->PdgToId(1000010020) != -1) {
+      sprintf(cc, "%-25s = ", "O_p,d,t = N_p N_t/N_d^2");
+      ret += QString(cc);
+      ret += QString::number(  model->TotalDensities()[model->TPS()->PdgToId(2212)] * model->TotalDensities()[model->TPS()->PdgToId(1000010030)] / model->TotalDensities()[model->TPS()->PdgToId(1000010020)] / model->TotalDensities()[model->TPS()->PdgToId(1000010020)] ) + "\r\n";
+
+      sprintf(cc, "%-25s = ", "delta_n");
+      ret += QString(cc);
+      ret += QString::number( (9./4.) * pow(4./3., 3./2.) * model->TotalDensities()[model->TPS()->PdgToId(2212)] * model->TotalDensities()[model->TPS()->PdgToId(1000010030)] / model->TotalDensities()[model->TPS()->PdgToId(1000010020)] / model->TotalDensities()[model->TPS()->PdgToId(1000010020)] - 1.) + "\r\n";
+    }
+  }
+
   if (model->IsFluctuationsCalculated()) {
     ret += "\r\n";
 

--- a/src/library/HRGBase/Broyden.cpp
+++ b/src/library/HRGBase/Broyden.cpp
@@ -45,6 +45,7 @@ namespace thermalfist {
     for (size_t i = 0; i < x.size(); ++i) {
       h[i] = m_dx*abs(h[i]);
       if (h[i] == 0.0) h[i] = m_dx;
+      if (h[i] < 1.e-10) h[i] = 1.e-10;
       //h[i] = max(m_dx, h[i]);
     }
 

--- a/src/library/HRGBase/ThermalModelBase.cpp
+++ b/src/library/HRGBase/ThermalModelBase.cpp
@@ -946,7 +946,8 @@ namespace thermalfist {
             int c1 = 0;
             //if (i == 0) c1 = m_TPS->Particles()[k].BaryonCharge();
             if (i == 0) c1 = 1 * (m_TPS->Particles()[k].PdgId() == 2212) - 1 * (m_TPS->Particles()[k].PdgId() == -2212);
-            if (i == 1) c1 = m_TPS->Particles()[k].ElectricCharge();
+            //if (i == 1) c1 = m_TPS->Particles()[k].ElectricCharge();
+            if (i == 1) c1 = 1 * (m_TPS->Particles()[k].PdgId() == 211) - 1 * (m_TPS->Particles()[k].PdgId() == -211);
             if (i == 2) c1 = 1 * (m_TPS->Particles()[k].PdgId() == 321) - 1 * (m_TPS->Particles()[k].PdgId() == -321);
             if (i == 3) c1 = m_TPS->Particles()[k].Charm();
             for (size_t kp = 0; kp < m_TotalCorrel.size(); ++kp) {
@@ -954,7 +955,8 @@ namespace thermalfist {
                 int c2 = 0;
                 //if (j == 0) c2 = m_TPS->Particles()[kp].BaryonCharge();
                 if (j == 0) c2 = 1 * (m_TPS->Particles()[kp].PdgId() == 2212) - 1 * (m_TPS->Particles()[kp].PdgId() == -2212);
-                if (j == 1) c2 = m_TPS->Particles()[kp].ElectricCharge();
+                //if (j == 1) c2 = m_TPS->Particles()[kp].ElectricCharge();
+                if (j == 1) c2 = 1 * (m_TPS->Particles()[kp].PdgId() == 211) - 1 * (m_TPS->Particles()[kp].PdgId() == -211);
                 if (j == 2) c2 = 1 * (m_TPS->Particles()[kp].PdgId() == 321) - 1 * (m_TPS->Particles()[kp].PdgId() == -321);
                 if (j == 3) c2 = m_TPS->Particles()[kp].Charm();
                 m_ProxySusc[i][j] += c1 * c2 * m_TotalCorrel[k][kp];
@@ -965,6 +967,9 @@ namespace thermalfist {
         m_ProxySusc[i][j] = m_ProxySusc[i][j] / m_Parameters.T / m_Parameters.T / xMath::GeVtoifm() / xMath::GeVtoifm() / xMath::GeVtoifm();
       }
     }
+
+    printf("chi2netp/chi2skellam = %lf\n", m_ProxySusc[0][0] / (m_densitiestotal[m_TPS->PdgToId(2212)] + m_densitiestotal[m_TPS->PdgToId(-2212)]) * pow(m_Parameters.T * xMath::GeVtoifm(), 3));
+    printf("chi2netpi/chi2skellam = %lf\n", m_ProxySusc[1][1] / (m_densitiestotal[m_TPS->PdgToId(211)] + m_densitiestotal[m_TPS->PdgToId(-211)]) * pow(m_Parameters.T * xMath::GeVtoifm(), 3));
   }
 
   void ThermalModelBase::CalculateFluctuations() {

--- a/src/library/HRGBase/ThermalModelBase.cpp
+++ b/src/library/HRGBase/ThermalModelBase.cpp
@@ -968,8 +968,8 @@ namespace thermalfist {
       }
     }
 
-    printf("chi2netp/chi2skellam = %lf\n", m_ProxySusc[0][0] / (m_densitiestotal[m_TPS->PdgToId(2212)] + m_densitiestotal[m_TPS->PdgToId(-2212)]) * pow(m_Parameters.T * xMath::GeVtoifm(), 3));
-    printf("chi2netpi/chi2skellam = %lf\n", m_ProxySusc[1][1] / (m_densitiestotal[m_TPS->PdgToId(211)] + m_densitiestotal[m_TPS->PdgToId(-211)]) * pow(m_Parameters.T * xMath::GeVtoifm(), 3));
+    //printf("chi2netp/chi2skellam = %lf\n", m_ProxySusc[0][0] / (m_densitiestotal[m_TPS->PdgToId(2212)] + m_densitiestotal[m_TPS->PdgToId(-2212)]) * pow(m_Parameters.T * xMath::GeVtoifm(), 3));
+    //printf("chi2netpi/chi2skellam = %lf\n", m_ProxySusc[1][1] / (m_densitiestotal[m_TPS->PdgToId(211)] + m_densitiestotal[m_TPS->PdgToId(-211)]) * pow(m_Parameters.T * xMath::GeVtoifm(), 3));
   }
 
   void ThermalModelBase::CalculateFluctuations() {

--- a/src/library/HRGBase/ThermalModelBase.cpp
+++ b/src/library/HRGBase/ThermalModelBase.cpp
@@ -25,6 +25,7 @@ namespace thermalfist {
     m_TPS(TPS_), 
     m_Parameters(params),
     m_UseWidth(false),
+    m_PCE(false),
     m_Calculated(false),
     m_FeeddownCalculated(false),
     m_FluctuationsCalculated(false),
@@ -483,6 +484,11 @@ namespace thermalfist {
   void ThermalModelBase::SolveChemicalPotentials(double totB, double totQ, double totS, double totC,
     double muBinit, double muQinit, double muSinit, double muCinit,
     bool ConstrMuB, bool ConstrMuQ, bool ConstrMuS, bool ConstrMuC) {
+    if (UsePartialChemicalEquilibrium()) {
+      printf("**WARNING** PCE enabled, cannot assume chemical equilibrium to do optimization...");
+      return;
+    }
+
     m_Parameters.muB = muBinit;
     m_Parameters.muS = muSinit;
     m_Parameters.muQ = muQinit;

--- a/src/library/HRGBase/ThermalModelCanonical.cpp
+++ b/src/library/HRGBase/ThermalModelCanonical.cpp
@@ -153,7 +153,7 @@ namespace thermalfist {
     if (m_PartialZ.size() == 0)
       CalculateQuantumNumbersRange();
 
-    if (m_BMAX_list == 1 && m_BCE && m_QCE && m_SCE && m_CCE) {
+    if (m_BMAX_list == 1 && m_BCE && m_QCE && m_SCE && m_CCE && !UsePartialChemicalEquilibrium()) {
       m_Banalyt = true;
       m_Parameters.muB = 0.0;
       m_Parameters.muQ = 0.0;
@@ -291,7 +291,8 @@ Obtained: %lf\n\
     if (Vc < 0.0)
       Vc = m_Parameters.SVc;
 
-    FillChemicalPotentials();
+    if (!UsePartialChemicalEquilibrium()) 
+      FillChemicalPotentials();
 
     bool AllMuZero = true;
     for (int i = 0; i < m_TPS->ComponentsNumber(); ++i) {

--- a/src/library/HRGBase/ThermalModelCanonical.cpp
+++ b/src/library/HRGBase/ThermalModelCanonical.cpp
@@ -524,7 +524,7 @@ Obtained: %lf\n\
     }
 
     for (size_t iN = 0; iN < m_PartialZ.size(); ++iN) {
-      if (m_BMAX != 0 && m_BMAX != 1)
+      if (m_BMAX != 0 && m_BMAX != 1 && !m_Banalyt) // TODO: cross-check
         m_PartialZ[iN] /= 2. * xMath::Pi();
       if (m_QMAX != 0) {
         m_PartialZ[iN] /= 2. * xMath::Pi();
@@ -617,7 +617,7 @@ Obtained: %lf\n\
       }
       else {
         for (int n = 1; n <= tpart.ClusterExpansionOrder(); ++n) {
-          int ind = m_QNMap[QuantumNumbers(n*tpart.BaryonCharge(), n*tpart.ElectricCharge(), n*tpart.Strangeness(), n*tpart.Charm())];
+          int ind = m_QNMap[QuantumNumbers(m_BCE*n*tpart.BaryonCharge(), m_QCE*n*tpart.ElectricCharge(), m_SCE*n*tpart.Strangeness(), m_CCE*n*tpart.Charm())];
 
           double densityClusterN = tpart.DensityCluster(n, m_Parameters, IdealGasFunctions::ParticleDensity, m_UseWidth, m_Chem[i]);
 
@@ -647,10 +647,10 @@ Obtained: %lf\n\
           for (int n1 = 1; n1 <= n1max; ++n1) {
             for (int n2 = 1; n2 <= n2max; ++n2) {
               int ind = m_QNMap[QuantumNumbers(
-                n1*tpart1.BaryonCharge() + n2 * tpart2.BaryonCharge(),
-                n1*tpart1.ElectricCharge() + n2 * tpart2.ElectricCharge(),
-                n1*tpart1.Strangeness() + n2 * tpart2.Strangeness(),
-                n1*tpart1.Charm() + n2 * tpart2.Charm())];
+                m_BCE*(n1*tpart1.BaryonCharge() + n2 * tpart2.BaryonCharge()),
+                m_QCE*(n1*tpart1.ElectricCharge() + n2 * tpart2.ElectricCharge()),
+                m_SCE*(n1*tpart1.Strangeness() + n2 * tpart2.Strangeness()),
+                m_CCE*(n1*tpart1.Charm() + n2 * tpart2.Charm()))];
 
               double densityClusterN1 = tpart1.DensityCluster(n1, m_Parameters, IdealGasFunctions::ParticleDensity, m_UseWidth, m_Chem[i]);
               double densityClusterN2 = tpart2.DensityCluster(n2, m_Parameters, IdealGasFunctions::ParticleDensity, m_UseWidth, m_Chem[j]);

--- a/src/library/HRGBase/ThermalModelCanonical.cpp
+++ b/src/library/HRGBase/ThermalModelCanonical.cpp
@@ -323,18 +323,32 @@ Obtained: %lf\n\
         || tpart.CalculationType() != IdealGasFunctions::ClusterExpansion) {
         int ind = m_QNMap[QuantumNumbers(m_BCE * tpart.BaryonCharge(), m_QCE * tpart.ElectricCharge(), m_SCE * tpart.Strangeness(), m_CCE * tpart.Charm())];
         if (ind < static_cast<int>(Nsx.size())) {
-          double tdens = tpart.DensityCluster(1, m_Parameters, IdealGasFunctions::ParticleDensity, m_UseWidth, 0.);
-          Nsx[ind] += tdens * cosh(m_Chem[i] / m_Parameters.T);
-          Nsy[ind] += tdens * sinh(m_Chem[i] / m_Parameters.T);
+          if (!UsePartialChemicalEquilibrium()) {
+            double tdens = tpart.DensityCluster(1, m_Parameters, IdealGasFunctions::ParticleDensity, m_UseWidth, 0.);
+            Nsx[ind] += tdens * cosh(m_Chem[i] / m_Parameters.T);
+            Nsy[ind] += tdens * sinh(m_Chem[i] / m_Parameters.T);
+          }
+          // Currently only works at mu = 0!!
+          else {
+            double tdens = tpart.DensityCluster(1, m_Parameters, IdealGasFunctions::ParticleDensity, m_UseWidth, m_Chem[i]);
+            Nsx[ind] += tdens;
+          }
         }
       }
       else {
         for (int n = 1; n <= tpart.ClusterExpansionOrder(); ++n) {
           int ind = m_QNMap[QuantumNumbers(m_BCE*n*tpart.BaryonCharge(), m_QCE*n*tpart.ElectricCharge(), m_SCE*n*tpart.Strangeness(), m_CCE*n*tpart.Charm())];
           if (ind < static_cast<int>(Nsx.size())) {
-            double tdens = tpart.DensityCluster(n, m_Parameters, IdealGasFunctions::ParticleDensity, m_UseWidth, 0.) / static_cast<double>(n); // TODO: Check
-            Nsx[ind] += tdens * cosh(n * m_Chem[i] / m_Parameters.T);
-            Nsy[ind] += tdens * sinh(n * m_Chem[i] / m_Parameters.T);
+            if (!UsePartialChemicalEquilibrium()) {
+              double tdens = tpart.DensityCluster(n, m_Parameters, IdealGasFunctions::ParticleDensity, m_UseWidth, 0.) / static_cast<double>(n); // TODO: Check
+              Nsx[ind] += tdens * cosh(n * m_Chem[i] / m_Parameters.T);
+              Nsy[ind] += tdens * sinh(n * m_Chem[i] / m_Parameters.T);
+            }
+            // Currently only works at mu = 0!!
+            else {
+              double tdens = tpart.DensityCluster(n, m_Parameters, IdealGasFunctions::ParticleDensity, m_UseWidth, m_Chem[i]) / static_cast<double>(n); // TODO: Check
+              Nsx[ind] += tdens;
+            }
           }
         }
       }

--- a/src/library/HRGBase/ThermalModelCanonicalCharm.cpp
+++ b/src/library/HRGBase/ThermalModelCanonicalCharm.cpp
@@ -84,6 +84,11 @@ namespace thermalfist {
   }
 
   void ThermalModelCanonicalCharm::CalculatePrimordialDensities() {
+    if (UsePartialChemicalEquilibrium()) {
+      printf("**ERROR** ThermalModelCanonicalCharm::CalculatePrimordialDensities(): PCE not supported!\n");
+      exit(1);
+    }
+
     m_FluctuationsCalculated = false;
     m_energydensitiesGCE.resize(0);
 

--- a/src/library/HRGBase/ThermalModelCanonicalStrangeness.cpp
+++ b/src/library/HRGBase/ThermalModelCanonicalStrangeness.cpp
@@ -138,6 +138,11 @@ namespace thermalfist {
   }
 
   void ThermalModelCanonicalStrangeness::CalculatePrimordialDensities() {
+    if (UsePartialChemicalEquilibrium()) {
+      printf("**ERROR** ThermalModelCanonicalStrangeness::CalculatePrimordialDensities(): PCE not supported!\n");
+      exit(1);
+    }
+
     m_FluctuationsCalculated = false;
 
     m_energydensitiesGCE.resize(0);

--- a/src/library/HRGEventGenerator/CylindricalBlastWaveEventGenerator.cpp
+++ b/src/library/HRGEventGenerator/CylindricalBlastWaveEventGenerator.cpp
@@ -20,15 +20,15 @@ namespace thermalfist {
     m_THM = NULL;
   }
 
-  CylindricalBlastWaveEventGenerator::CylindricalBlastWaveEventGenerator(ThermalParticleSystem * TPS, const EventGeneratorConfiguration & config, double T, double beta, double etamax, double npow) : 
-    m_T(T), m_Beta(beta), m_EtaMax(etamax), m_n(npow)
+  CylindricalBlastWaveEventGenerator::CylindricalBlastWaveEventGenerator(ThermalParticleSystem * TPS, const EventGeneratorConfiguration & config, double T, double betas, double etamax, double npow) : 
+    m_T(T), m_BetaS(betas), m_EtaMax(etamax), m_n(npow)
   {
     SetConfiguration(TPS, config);
 
     SetMomentumGenerators();
   }
 
-  CylindricalBlastWaveEventGenerator::CylindricalBlastWaveEventGenerator(ThermalModelBase *THM, double T, double beta, double etamax, double npow, bool /*onlyStable*/, EventGeneratorConfiguration::ModelType EV, ThermalModelBase *THMEVVDW) :m_T(T), m_Beta(beta), m_EtaMax(etamax), m_n(npow) {
+  CylindricalBlastWaveEventGenerator::CylindricalBlastWaveEventGenerator(ThermalModelBase *THM, double T, double betas, double etamax, double npow, bool /*onlyStable*/, EventGeneratorConfiguration::ModelType EV, ThermalModelBase *THMEVVDW) :m_T(T), m_BetaS(betas), m_EtaMax(etamax), m_n(npow) {
     EventGeneratorConfiguration::ModelType modeltype = EV;
     EventGeneratorConfiguration::Ensemble ensemble = EventGeneratorConfiguration::GCE;
     if (THM->Ensemble() == ThermalModelBase::CE)
@@ -69,11 +69,18 @@ namespace thermalfist {
     SetMomentumGenerators();
   }
 
-  void CylindricalBlastWaveEventGenerator::SetParameters(double T, double beta, double etamax, double npow) {
+  void CylindricalBlastWaveEventGenerator::SetParameters(double T, double betas, double etamax, double npow) {
     m_T = T;
-    m_Beta = beta;
+    m_BetaS = betas;
     m_EtaMax = etamax;
     m_n = npow;
+
+    SetMomentumGenerators();
+  }
+
+  void CylindricalBlastWaveEventGenerator::SetMeanBetaT(double betaT)
+  {
+    m_BetaS = (2. + m_n) / 2. * betaT;
 
     SetMomentumGenerators();
   }
@@ -84,7 +91,7 @@ namespace thermalfist {
     m_BWGens.resize(0);
     if (m_THM != NULL) {
       for (size_t i = 0; i < m_THM->TPS()->Particles().size(); ++i) {
-        m_MomentumGens.push_back(new RandomGenerators::SSHMomentumGenerator(m_T, m_Beta, m_EtaMax, m_n, m_THM->TPS()->Particles()[i].Mass()));
+        m_MomentumGens.push_back(new RandomGenerators::SSHMomentumGenerator(m_T, m_BetaS, m_EtaMax, m_n, m_THM->TPS()->Particles()[i].Mass()));
 
         double T = m_THM->Parameters().T;
         double Mu = m_THM->ChemicalPotential(i);

--- a/src/library/HRGEventGenerator/EventGeneratorBase.cpp
+++ b/src/library/HRGEventGenerator/EventGeneratorBase.cpp
@@ -89,7 +89,11 @@ namespace thermalfist {
     m_THM->ConstrainMuQ(false);
     m_THM->ConstrainMuS(false);
     m_THM->ConstrainMuC(false);
-    m_THM->FillChemicalPotentials();
+
+    if (!m_Config.fUsePCE)
+      m_THM->FillChemicalPotentials();
+    else
+      m_THM->SetChemicalPotentials(m_Config.fPCEChems);
 
     if (m_Config.fModelType != EventGeneratorConfiguration::PointParticle) {
       for (size_t i = 0; i < m_THM->Densities().size(); ++i) {
@@ -106,8 +110,10 @@ namespace thermalfist {
     }
 
     if (m_Config.fEnsemble == EventGeneratorConfiguration::CE) {
-      // The following procedure currently not used, but can be considered if SolveChemicalPotentials routine fails
-      if (0 && !(m_Config.B == 0 && m_Config.Q == 0 && m_Config.S == 0)) {
+      // The following procedure currently not used, 
+      // but can be considered if SolveChemicalPotentials routine fails
+      // Note to take into account PCE possiblity if this option is considered
+      if (0 && !(m_Config.B == 0 && m_Config.Q == 0 && m_Config.S == 0) && !m_Config.fUsePCE) {
         if (m_Config.S == 0 && !(m_Config.Q == 0 || m_Config.B == 0)) {
           double QBrat = (double)(m_Config.Q) / m_Config.B;
 
@@ -157,38 +163,41 @@ namespace thermalfist {
         }
       }
 
-      m_THM->SolveChemicalPotentials(m_Config.B, m_Config.Q, m_Config.S, m_Config.C,
-        m_THM->Parameters().muB, m_THM->Parameters().muQ, m_THM->Parameters().muS, m_THM->Parameters().muC);
-      if (m_THM->Parameters().muB != m_THM->Parameters().muB ||
-        m_THM->Parameters().muQ != m_THM->Parameters().muQ ||
-        m_THM->Parameters().muS != m_THM->Parameters().muS ||
-        m_THM->Parameters().muC != m_THM->Parameters().muC) {
-        printf("**WARNING** Could not constrain chemical potentials. Setting all to zero...\n");
-        m_THM->SetBaryonChemicalPotential(0.);
-        m_THM->SetElectricChemicalPotential(0.);
-        m_THM->SetStrangenessChemicalPotential(0.);
-        m_THM->SetCharmChemicalPotential(0.);
-        m_THM->FillChemicalPotentials();
+      if (!m_Config.fUsePCE) {
+
+        m_THM->SolveChemicalPotentials(m_Config.B, m_Config.Q, m_Config.S, m_Config.C,
+          m_THM->Parameters().muB, m_THM->Parameters().muQ, m_THM->Parameters().muS, m_THM->Parameters().muC);
+        if (m_THM->Parameters().muB != m_THM->Parameters().muB ||
+          m_THM->Parameters().muQ != m_THM->Parameters().muQ ||
+          m_THM->Parameters().muS != m_THM->Parameters().muS ||
+          m_THM->Parameters().muC != m_THM->Parameters().muC) {
+          printf("**WARNING** Could not constrain chemical potentials. Setting all to zero...\n");
+          m_THM->SetBaryonChemicalPotential(0.);
+          m_THM->SetElectricChemicalPotential(0.);
+          m_THM->SetStrangenessChemicalPotential(0.);
+          m_THM->SetCharmChemicalPotential(0.);
+          m_THM->FillChemicalPotentials();
+        }
+        m_Config.CFOParameters.muB = m_THM->Parameters().muB;
+        m_Config.CFOParameters.muS = m_THM->Parameters().muS;
+        m_Config.CFOParameters.muQ = m_THM->Parameters().muQ;
+        m_Config.CFOParameters.muC = m_THM->Parameters().muC;
+
+        std::cout << "Chemical potentials constrained!\n" << "muB = "
+          << m_Config.CFOParameters.muB << " muQ = "
+          << m_Config.CFOParameters.muQ << " muS = "
+          << m_Config.CFOParameters.muS << " muC = "
+          << m_Config.CFOParameters.muC << "\n";
+
+        std::cout << "B = " << m_THM->CalculateBaryonDensity() * m_THM->Parameters().V
+          << " Q = " << m_THM->CalculateChargeDensity() * m_THM->Parameters().V
+          << " S = " << m_THM->CalculateStrangenessDensity() * m_THM->Parameters().V
+          << " C = " << m_THM->CalculateCharmDensity() * m_THM->Parameters().V
+          << "\n";
       }
-      m_Config.CFOParameters.muB = m_THM->Parameters().muB;
-      m_Config.CFOParameters.muS = m_THM->Parameters().muS;
-      m_Config.CFOParameters.muQ = m_THM->Parameters().muQ;
-      m_Config.CFOParameters.muC = m_THM->Parameters().muC;
-
-      std::cout << "Chemical potentials constrained!\n" << "muB = " 
-        << m_Config.CFOParameters.muB << " muQ = " 
-        << m_Config.CFOParameters.muQ << " muS = " 
-        << m_Config.CFOParameters.muS << " muC = " 
-        << m_Config.CFOParameters.muC << "\n";
-
-      std::cout << "B = " << m_THM->CalculateBaryonDensity() * m_THM->Parameters().V 
-        << " Q = " << m_THM->CalculateChargeDensity() * m_THM->Parameters().V 
-        << " S = " << m_THM->CalculateStrangenessDensity() * m_THM->Parameters().V 
-        << " C = " << m_THM->CalculateCharmDensity() * m_THM->Parameters().V
-        << "\n";
     }
 
-    if (m_Config.fEnsemble == EventGeneratorConfiguration::SCE) {
+    if (m_Config.fEnsemble == EventGeneratorConfiguration::SCE && !m_Config.fUsePCE) {
       m_THM->ConstrainMuS(true);
       m_THM->ConstrainMuC(true);
       m_THM->ConstrainChemicalPotentials();
@@ -197,7 +206,7 @@ namespace thermalfist {
       m_Config.CFOParameters.muC = m_THM->Parameters().muC;
     }
 
-    if (m_Config.fEnsemble == EventGeneratorConfiguration::CCE) {
+    if (m_Config.fEnsemble == EventGeneratorConfiguration::CCE && !m_Config.fUsePCE) {
       m_THM->ConstrainMuC(true);
       m_THM->ConstrainChemicalPotentials();
       m_THM->FillChemicalPotentials();
@@ -869,9 +878,11 @@ namespace thermalfist {
 
 
       // Light nuclei first
+      bool fl = false; // Whether light nuclei appear at all
 
       for (size_t i = 0; i < m_THM->TPS()->Particles().size(); ++i) {
         if (abs(m_THM->TPS()->Particles()[i].BaryonCharge()) > 1) {
+          fl = true;
           double mean = densities[i] * m_THM->Volume();
           int total = RandomGenerators::RandomPoisson(mean);
           totals[i] = total;
@@ -884,10 +895,31 @@ namespace thermalfist {
 
       // Then all hadrons
 
+      int tB = 0, tAB = 0;
       // First total baryons and antibaryons from the Poisson distribution
-      int tB = RandomGenerators::RandomPoisson(m_MeanB);
-      int tAB = RandomGenerators::RandomPoisson(m_MeanAB);
-      if (tB - tAB != m_THM->Parameters().B - netB) continue;
+      if (fl) {
+        /*tB = RandomGenerators::RandomPoisson(m_MeanB);
+        tAB = RandomGenerators::RandomPoisson(m_MeanAB);
+        if (tB - tAB != m_THM->Parameters().B - netB) continue;*/
+        if (RandomGenerators::randgenMT.rand() > RandomGenerators::SkellamProbability(m_THM->Parameters().B - netB, m_MeanB, m_MeanAB))
+          continue;
+      }
+
+      // Generate from the Bessel distribution, using Devroye's method, if no light nuclei
+      {
+        int nu = m_THM->Parameters().B - netB;
+        if (nu < 0) nu = -nu;
+        double a = 2. * sqrt(m_MeanB * m_MeanAB);
+        int BessN = RandomGenerators::BesselDistributionGenerator::RandomBesselDevroye3(a, nu);
+        if (m_THM->Parameters().B - netB < 0) {
+          tB = BessN;
+          tAB = nu + tB;
+        }
+        else {
+          tAB = BessN;
+          tB = nu + tAB;
+        }
+      }
 
       // Then individual baryons and antibaryons from the multinomial distribution
       for (int i = 0; i < tB; ++i) {
@@ -912,10 +944,29 @@ namespace thermalfist {
       }
 
       // Total numbers of (anti)strange mesons
+      
       int tSM = RandomGenerators::RandomPoisson(m_MeanSM);
       int tASM = RandomGenerators::RandomPoisson(m_MeanASM);
-
       if (netS != tASM - tSM + m_THM->Parameters().S) continue;
+
+      //int tSM = 0, tASM = 0;
+      //if (RandomGenerators::randgenMT.rand() > RandomGenerators::SkellamProbability(m_THM->Parameters().S - netS, m_MeanSM, m_MeanASM))
+      //    continue;
+      //// Generate from the Bessel distribution, using Devroye's method, if no light nuclei
+      //{
+      //  int nu = m_THM->Parameters().S - netS;
+      //  if (nu < 0) nu = -nu;
+      //  double a = 2. * sqrt(m_MeanSM * m_MeanASM);
+      //  int BessN = RandomGenerators::BesselDistributionGenerator::RandomBesselDevroye3(a, nu);
+      //  if (m_THM->Parameters().S - netS < 0) {
+      //    tSM = BessN;
+      //    tASM = nu + tSM;
+      //  }
+      //  else {
+      //    tASM = BessN;
+      //    tSM = nu + tASM;
+      //  }
+      //}
 
       // Multinomial distribution for individual numbers of (anti)strange mesons
       for (int i = 0; i < tSM; ++i) {
@@ -940,8 +991,26 @@ namespace thermalfist {
       // Total numbers of remaining electrically charged mesons
       int tCM = RandomGenerators::RandomPoisson(m_MeanCM);
       int tACM = RandomGenerators::RandomPoisson(m_MeanACM);
-
       if (netQ != tACM - tCM + m_THM->Parameters().Q) continue;
+
+      //int tCM = 0, tACM = 0;
+      //if (RandomGenerators::randgenMT.rand() > RandomGenerators::SkellamProbability(m_THM->Parameters().Q - netQ, m_MeanCM, m_MeanACM))
+      //    continue;
+      //// Generate from the Bessel distribution, using Devroye's method, if no light nuclei
+      //{
+      //  int nu = m_THM->Parameters().Q - netQ;
+      //  if (nu < 0) nu = -nu;
+      //  double a = 2. * sqrt(m_MeanCM * m_MeanACM);
+      //  int BessN = RandomGenerators::BesselDistributionGenerator::RandomBesselDevroye3(a, nu);
+      //  if (m_THM->Parameters().Q - netQ < 0) {
+      //    tCM = BessN;
+      //    tACM = nu + tCM;
+      //  }
+      //  else {
+      //    tACM = BessN;
+      //    tCM = nu + tACM;
+      //  }
+      //}
 
       // Multinomial distribution for individual numbers of remaining electrically charged mesons
       for (int i = 0; i < tCM; ++i) {
@@ -1055,6 +1124,7 @@ namespace thermalfist {
       }
     }
 
+
     bool flag_repeat = true;
     while (flag_repeat) {
       flag_repeat = false;
@@ -1118,7 +1188,19 @@ namespace thermalfist {
         }
       }
     }
+    
+    for (int i = primParticles.size() - 1; i >= 0; --i)
+      ret.AllParticles.insert(ret.AllParticles.end(), primParticles[i].begin(), primParticles[i].end());
     return ret;
+  }
+
+  EventGeneratorConfiguration::EventGeneratorConfiguration()
+  {
+    fEnsemble = GCE;
+    fModelType = PointParticle;
+    CFOParameters = ThermalModelParameters();
+    B = Q = S = C = 0;
+    fUsePCE = false;
   }
 
 } // namespace thermalfist

--- a/src/library/HRGEventGenerator/EventGeneratorBase.cpp
+++ b/src/library/HRGEventGenerator/EventGeneratorBase.cpp
@@ -277,10 +277,6 @@ namespace thermalfist {
         m_AntiChargeMesons.push_back(std::make_pair(densities[i], i));
         m_MeanACM += densities[i];
       }
-      else if (m_THM->TPS()->Particles()[i].BaryonCharge() == 0 && m_THM->TPS()->Particles()[i].Strangeness() == 0 && m_THM->TPS()->Particles()[i].ElectricCharge() == 1) {
-        m_ChargeMesons.push_back(std::make_pair(densities[i], i));
-        m_MeanCM += densities[i];
-      }
       else if (m_THM->TPS()->Particles()[i].BaryonCharge() == 0 && m_THM->TPS()->Particles()[i].Strangeness() == 0 && m_THM->TPS()->Particles()[i].ElectricCharge() == 0 && m_THM->TPS()->Particles()[i].Charm() == 1) {
         m_CharmMesons.push_back(std::make_pair(densities[i], i));
         m_MeanCHRMM += densities[i];
@@ -698,7 +694,7 @@ namespace thermalfist {
           std::vector<int> totalsaux2(m_THM->TPS()->Particles().size(), 0);
           int netC = 0;
           for (size_t i = 0; i < totalsaux.size(); ++i) {
-            if (m_THM->TPS()->Particles()[i].Strangeness() > 0) {
+            if (m_THM->TPS()->Particles()[i].Charm() > 0) {
               for (int j = 0; j < totalsaux[i]; ++j) {
                 if (RandomGenerators::randgenMT.rand() < fraction) {
                   totalsaux2[i]++;

--- a/src/library/HRGEventGenerator/EventGeneratorBase.cpp
+++ b/src/library/HRGEventGenerator/EventGeneratorBase.cpp
@@ -898,19 +898,22 @@ namespace thermalfist {
       int tB = 0, tAB = 0;
       // First total baryons and antibaryons from the Poisson distribution
       if (fl) {
-        /*tB = RandomGenerators::RandomPoisson(m_MeanB);
+        tB = RandomGenerators::RandomPoisson(m_MeanB);
         tAB = RandomGenerators::RandomPoisson(m_MeanAB);
-        if (tB - tAB != m_THM->Parameters().B - netB) continue;*/
-        if (RandomGenerators::randgenMT.rand() > RandomGenerators::SkellamProbability(m_THM->Parameters().B - netB, m_MeanB, m_MeanAB))
-          continue;
+        if (tB - tAB != m_THM->Parameters().B - netB) continue;
+        //if (RandomGenerators::randgenMT.rand() > RandomGenerators::SkellamProbability(m_THM->Parameters().B - netB, m_MeanB, m_MeanAB))
+        //  continue;
       }
-
+      else
       // Generate from the Bessel distribution, using Devroye's method, if no light nuclei
       {
         int nu = m_THM->Parameters().B - netB;
         if (nu < 0) nu = -nu;
         double a = 2. * sqrt(m_MeanB * m_MeanAB);
-        int BessN = RandomGenerators::BesselDistributionGenerator::RandomBesselDevroye3(a, nu);
+        //int BessN = RandomGenerators::BesselDistributionGenerator::RandomBesselDevroye3(a, nu);
+        //int BessN = RandomGenerators::BesselDistributionGenerator::RandomBesselPoisson(a, nu);
+        //int BessN = RandomGenerators::BesselDistributionGenerator::RandomBesselCombined(a, nu);
+        int BessN = RandomGenerators::BesselDistributionGenerator::RandomBesselDevroye1(a, nu);
         if (m_THM->Parameters().B - netB < 0) {
           tB = BessN;
           tAB = nu + tB;

--- a/src/library/HRGEventGenerator/EventGeneratorBase.cpp
+++ b/src/library/HRGEventGenerator/EventGeneratorBase.cpp
@@ -1194,6 +1194,41 @@ namespace thermalfist {
     return ret;
   }
 
+  void EventGeneratorBase::SetVolume(double V)
+  {
+    if (m_Config.fEnsemble != EventGeneratorConfiguration::GCE)
+      RescaleCEMeans(V / m_THM->Volume());
+    m_THM->SetVolume(V); 
+    m_Config.CFOParameters.V = V; 
+    m_THM->SetCanonicalVolume(V); 
+    m_Config.CFOParameters.SVc = V; 
+  }
+
+  void EventGeneratorBase::RescaleCEMeans(double Vmod)
+  {
+    m_MeanB      *= Vmod;
+    m_MeanAB     *= Vmod;
+    m_MeanSM     *= Vmod;
+    m_MeanASM    *= Vmod;
+    m_MeanCM     *= Vmod;
+    m_MeanACM    *= Vmod;
+    m_MeanCHRMM  *= Vmod;
+    m_MeanACHRMM *= Vmod;
+    m_MeanCHRM   *= Vmod;
+    m_MeanACHRM  *= Vmod;
+
+    for (int i = 0; i < static_cast<int>(m_Baryons.size()); ++i)            m_Baryons[i].first *= Vmod;
+    for (int i = 0; i < static_cast<int>(m_AntiBaryons.size()); ++i)        m_AntiBaryons[i].first *= Vmod;
+    for (int i = 0; i < static_cast<int>(m_StrangeMesons.size()); ++i)      m_StrangeMesons[i].first *= Vmod;
+    for (int i = 0; i < static_cast<int>(m_AntiStrangeMesons.size()); ++i)  m_AntiStrangeMesons[i].first *= Vmod;
+    for (int i = 0; i < static_cast<int>(m_ChargeMesons.size()); ++i)       m_ChargeMesons[i].first *= Vmod;
+    for (int i = 0; i < static_cast<int>(m_AntiChargeMesons.size()); ++i)   m_AntiChargeMesons[i].first *= Vmod;
+    for (int i = 0; i < static_cast<int>(m_CharmMesons.size()); ++i)        m_CharmMesons[i].first *= Vmod;
+    for (int i = 0; i < static_cast<int>(m_AntiCharmMesons.size()); ++i)    m_AntiCharmMesons[i].first *= Vmod;
+    for (int i = 0; i < static_cast<int>(m_CharmAll.size()); ++i)           m_CharmAll[i].first *= Vmod;
+    for (int i = 0; i < static_cast<int>(m_AntiCharmAll.size()); ++i)       m_AntiCharmAll[i].first *= Vmod;
+  }
+
   EventGeneratorConfiguration::EventGeneratorConfiguration()
   {
     fEnsemble = GCE;

--- a/src/library/HRGEventGenerator/ParticleDecaysMC.cpp
+++ b/src/library/HRGEventGenerator/ParticleDecaysMC.cpp
@@ -151,8 +151,10 @@ namespace thermalfist {
       for (size_t i = 0; i < ret1.size(); ++i)
         ret.push_back(ret1[i]);
 
-      for (size_t i = 0; i < ret.size(); ++i)
+      for (size_t i = 0; i < ret.size(); ++i) {
         ret[i].MotherPDGID = Mother.PDGID;
+        ret[i].epoch = Mother.epoch + 1;
+      }
 
 #ifdef DEBUGDECAYS
       for (int i = 0; i < ret.size(); ++i)

--- a/src/library/HRGEventGenerator/RandomGenerators.cpp
+++ b/src/library/HRGEventGenerator/RandomGenerators.cpp
@@ -108,6 +108,11 @@ namespace thermalfist {
       //}
     }
 
+    double SkellamProbability(int k, double mu1, double mu2)
+    {
+      return exp(-(mu1 + mu2)) * pow(sqrt(mu1 / mu2), k) * xMath::BesselI(k, 2. * sqrt(mu1 * mu2));
+    }
+
 
     double SiemensRasmussenMomentumGenerator::g(double x) const {
       double tp = -log(x);
@@ -566,6 +571,175 @@ namespace thermalfist {
       return m_part->ThermalMassDistribution(M, m_T, m_Mu, m_part->TotalWidtheBW(M));
     }
 
-  }
+    double BesselDistributionGenerator::pn(int n, double a, int nu)
+    {
+      if (nu < 0 || n < 0) return 0.0;
+      double nfact = 1., nnufact = 1.;
+      for (int i = 1; i <= n; ++i)
+        nfact *= i;
+
+      nnufact = nfact;
+      for (int i = n + 1; i <= n + nu; ++i)
+        nnufact *= i;
+
+      return pow(a / 2., 2 * n + nu) / xMath::BesselI(nu, a) / nfact / nnufact;
+    }
+
+    double BesselDistributionGenerator::chi2(double a, int nu)
+    {
+      return mu(a, nu) + (1. / 4.) * a * a * R(a, nu) * (R(a,nu+1) - R(a,nu));
+    }
+
+    double BesselDistributionGenerator::sig2(double a, int nu)
+    {
+      double tmp = m(a, nu) - mu(a, nu);
+      return chi2(a, nu) + tmp * tmp;
+    }
+
+    double BesselDistributionGenerator::Q2(double a, int nu)
+    {
+      double A = sqrt(a*a + nu*nu);
+      double B = sqrt(a*a + (nu+1.)*(nu+1.));
+      double tmp = 1. + a * a * (1. + B - A) / 2. / (nu + A) / (nu + 1. + B);
+      return a*a / 2. / (nu + A) + tmp * tmp;
+    }
+
+    int BesselDistributionGenerator::RandomBesselPoisson(double a, int nu, MTRand & rangen)
+    {
+      if (nu < 0 || a <= 0.) return 0;
+
+      while (true) {
+        int n1 = RandomPoisson(a / 2., rangen);
+        int n2 = RandomPoisson(a / 2., rangen);
+        if (n1 - n2 == nu)
+          return n2;
+      }
+
+      return 0;
+    }
+
+    double BesselDistributionGenerator::pmXmOverpm(int X, int tm, double a, int nu) {
+      double tf1 = 1., tf2 = 1.;
+      if (X > 0) {
+        for (int i = 1; i <= X; ++i) {
+          tf1 *= tm + i;
+          tf2 *= tm + nu + i;
+        }
+      }
+      else if (X < 0) {
+        for (int i = 1; i <= -X; ++i) {
+          tf1 *= tm + X + i;
+          tf2 *= tm + nu + X + i;
+        }
+        tf1 = 1. / tf1;
+        tf2 = 1. / tf2;
+      }
+
+      return pow(a / 2., 2 * X) / tf1 / tf2;
+    }
+
+    int BesselDistributionGenerator::RandomBesselDevroye1(double a, int nu, MTRand & rangen)
+    {
+      int tm = m(a, nu);
+      double pm = pn(tm, a, nu);
+      double w = 1. + pm / 2.;
+      while (true) {
+        double U = rangen.rand();
+        double W = rangen.rand();
+        int S = 1;
+        if (rangen.rand() < 0.5)
+          S = -1;
+
+        double Y = 0.;
+        if (U <= w / (1. + w)) {
+          double V = rangen.rand();
+          Y = V * w / pm;
+        }
+        else {
+          double E = -log(rangen.randDblExc());
+          Y = (w + E) / pm;
+        }
+        int X = S * std::round(Y);
+
+        if (tm + X < 0)
+          continue;
+
+        double pratio = pmXmOverpm(X, tm, a, nu);
+
+        if (W * std::min(1., exp(w - pm * Y)) <= pratio)
+          return tm + X;
+      }
+      return 0;
+    }
+
+    int BesselDistributionGenerator::RandomBesselDevroye2(double a, int nu, MTRand & rangen)
+    {
+      int tm = m(a, nu);
+      double tsig = sqrt(sig2(a, nu));
+      double q = std::max(1. / tsig / sqrt(648.), 1. / 3.);
+      while (true) {
+        double U = rangen.rand();
+        double W = rangen.rand();
+        int S = 1;
+        if (rangen.rand() < 0.5)
+          S = -1;
+
+        double Y = 0.;
+        if (U <= (1. + 2. / q) / (1. + 4. / q)) {
+          double V = rangen.rand();
+          Y = V * (1. / 2. + 1. / q);
+        }
+        else {
+          double E = -log(rangen.randDblExc());
+          Y = 1. / 2. + 1. / q + E / q;
+        }
+        int X = S * std::round(Y);
+
+        if (tm + X < 0)
+          continue;
+
+        double pratio = pmXmOverpm(X, tm, a, nu);
+
+        if (W * std::min(1., exp(1. + q/2. - q*Y)) <= pratio)
+          return tm + X;
+      }
+      return 0;
+    }
+
+    int BesselDistributionGenerator::RandomBesselDevroye3(double a, int nu, MTRand & rangen)
+    {
+      int tm = m(a, nu);
+      double tQ = sqrt(Q2(a, nu));
+      double q = std::max(1. / tQ / sqrt(648.), 1. / 3.);
+      while (true) {
+        double U = rangen.rand();
+        double W = rangen.rand();
+        int S = 1;
+        if (rangen.rand() < 0.5)
+          S = -1;
+
+        double Y = 0.;
+        if (U <= (1. + 2. / q) / (1. + 4. / q)) {
+          double V = rangen.rand();
+          Y = V * (1. / 2. + 1. / q);
+        }
+        else {
+          double E = -log(rangen.randDblExc());
+          Y = 1. / 2. + 1. / q + E / q;
+        }
+        int X = S * std::round(Y);
+
+        if (tm + X < 0)
+          continue;
+
+        double pratio = pmXmOverpm(X, tm, a, nu);
+
+        if (W * std::min(1., exp(1. + q/2. - q*Y)) <= pratio)
+          return tm + X;
+      }
+      return 0;
+    }
+
+}
 
 } // namespace thermalfist

--- a/src/library/HRGEventGenerator/SimpleEvent.cpp
+++ b/src/library/HRGEventGenerator/SimpleEvent.cpp
@@ -34,4 +34,28 @@ namespace thermalfist {
     fout << std::endl;
   }
 
+  void SimpleEvent::RapidityBoost(double dY)
+  {
+    for (size_t i = 0; i < Particles.size(); ++i)
+      Particles[i].RapidityBoost(dY);
+  }
+
+  SimpleEvent SimpleEvent::MergeEvents(const SimpleEvent & evt1, const SimpleEvent & evt2)
+  {
+    SimpleEvent ret;
+    ret.Particles.reserve(evt1.Particles.size() + evt2.Particles.size());
+    ret.Particles.insert(ret.Particles.end(), evt1.Particles.begin(), evt1.Particles.end());
+    ret.Particles.insert(ret.Particles.end(), evt2.Particles.begin(), evt2.Particles.end());
+
+    ret.AllParticles.reserve(evt1.AllParticles.size() + evt2.AllParticles.size());
+    ret.AllParticles.insert(ret.AllParticles.end(), evt1.AllParticles.begin(), evt1.AllParticles.end());
+    ret.AllParticles.insert(ret.AllParticles.end(), evt2.AllParticles.begin(), evt2.AllParticles.end());
+    
+    // TODO: check if proper to combine weights like that
+    ret.weight = evt1.weight * evt2.weight;
+    ret.logweight = evt1.logweight + evt2.logweight;
+
+    return ret;
+  }
+
 } // namespace thermalfist


### PR DESCRIPTION
### List of changes
- Improved performace of event generator. Exact baryon number conservation taken into account using [Devroye's method](https://doi.org/10.1016/S0167-7152(02)00055-X)
- Possibility to set volume on event-by-event basis in the event generator
- Proxy net-charge fluctuations now corresponds to net-pion fluctuations in the final state
- The beta parameter in cylindrical blast-wave model now corresponds to the surface velocity parameter \beta_s
- Mixed-canonical ensembles are now available through GUI, using canonical ensemble and conservation laws dialog

### Bugfixes
- Mixed-canonical ensembles now work at non-zero densities of conserved charges
- Correct analytic calculation of fluctuations in mixed-canonical ensembles
- Small violation of electric charge conservation in event generator within full canonical ensemble