### PR TITLE
Swapped p0 write order to match header

### DIFF
--- a/src/library/HRGEventGenerator/EventWriter.cpp
+++ b/src/library/HRGEventGenerator/EventWriter.cpp
@@ -71,12 +71,11 @@ namespace thermalfist {
 
       m_fout << std::setw(tabsize) << part.PDGID;
 
+      m_fout << std::setw(tabsize) << part.p0;
 
       m_fout << std::setw(tabsize) << part.px
         << std::setw(tabsize) << part.py
         << std::setw(tabsize) << part.pz;
-
-      m_fout << std::setw(tabsize) << part.p0;
 
       m_fout << std::endl;
     }


### PR DESCRIPTION
Changed p0 to write before px, py, pz to match the column headers.